### PR TITLE
Fix title and headers in doc pages, clean up entry index.html

### DIFF
--- a/accountinformation/docs.html
+++ b/accountinformation/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>AccountInformation Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the AccountInformation framework</div>
 			<select id="version-selector" class="hidden">
 					<option value="v1" selected>AccountInformation Api v1</option>
 			</select>

--- a/accountsettings/docs.html
+++ b/accountsettings/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>AccountSettings Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the AccountSettings framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>AccountSettings Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/adconfiguration/docs.html
+++ b/adconfiguration/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>AdConfiguration Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the AdConfiguration framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>AdConfiguration Api v1</option>
 					<option value="v2" selected>AdConfiguration Api v2</option>

--- a/ads/docs.html
+++ b/ads/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Ads Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Ads framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Ads Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/api/docs.html
+++ b/api/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>API Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for API framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>API Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/assetdelivery/docs.html
+++ b/assetdelivery/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>AssetDelivery Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the AssetDelivery framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>AssetDelivery Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/auth/docs.html
+++ b/auth/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Authentication Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Authentication framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Auth Api v1</option>
 					<option value="v2" selected>Auth Api v2</option>

--- a/avatar/docs.html
+++ b/avatar/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Avatar Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Avatar framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Avatar Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/badges/docs.html
+++ b/badges/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Badge Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Badges framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Badges Api v1</option>
 					<option value="v2" selected>Badges Api v2</option>

--- a/billing/docs.html
+++ b/billing/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Billing Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Billing framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Billing Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/catalog/docs.html
+++ b/catalog/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Catalog Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Catalog framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Catalog Api v1</option>
 					<option value="v2" selected>Catalog Api v2</option>

--- a/cdnproviders/docs.html
+++ b/cdnproviders/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>CDNProviders Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the CDNProviders framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>CDNProviders Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/chat/docs.html
+++ b/chat/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Chat Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Chat framework</div>
 			<select id="version-selector" class="">
-					<option value="v2" selected>AbTesting Api v1</option>
+					<option value="v2" selected>Chat Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/clientsettings/docs.html
+++ b/clientsettings/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>ClientSettings Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the ClientSettings framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>ClientSettings Api v1</option>
 					<option value="v2" selected>ClientSettings Api v2</option>

--- a/contacts/docs.html
+++ b/contacts/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Contacts Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Contacts framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Contacts Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/contentstore/docs.html
+++ b/contentstore/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>ContentStore Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the ContentStore framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>ContentStore Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/develop/docs.html
+++ b/develop/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Develop Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Develop framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Develop Api v1</option>
 					<option value="v2" selected>Develop Api v2</option>

--- a/economy/docs.html
+++ b/economy/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Economy Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Economy framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Economy Api v1</option>
 					<option value="v2" selected>Economy Api v2</option>

--- a/engagementpayouts/docs.html
+++ b/engagementpayouts/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>EngagementPayouts Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the EngagementPayouts framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>EngagementPayouts Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/files_api/docs.html
+++ b/files_api/docs.html
@@ -44,9 +44,8 @@
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
 			<div class="info_description" id="Description">Files.</div>
-			<select id="version-selector" class="">
+			<select id="version-selector" class="hidden">
 					<option value="v1" selected>Files Service v1</option>
-					<option value="v0">Files Service v0</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/followings/docs.html
+++ b/followings/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Followings Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -43,9 +43,9 @@
                 <a target="_blank" href="https://www.roblox.com/info/account-safety">Click here to learn more about keeping your account safe.</a>
             </div>
         </div>
-        <div class="info" id="doc_info">
+      <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Followings framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Followings Api v1</option>
 					<option value="v2" selected>Followings Api v2</option>

--- a/friends/docs.html
+++ b/friends/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Friends Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Friends framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Friends Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/gameinternationalization/docs.html
+++ b/gameinternationalization/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>GameInternationalization Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the GameInternationalization framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>GameInternationalization Api v1</option>
 					<option value="v2" selected>GameInternationalization Api v1</option>

--- a/games/docs.html
+++ b/games/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Games Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Games framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Games Api v1</option>
 					<option value="v2" selected>Games Api v1</option>

--- a/groups/docs.html
+++ b/groups/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Groups Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Groups framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Groups Api v1</option>
 					<option value="v2" selected>Groups Api v2</option>

--- a/groupsmoderation/docs.html
+++ b/groupsmoderation/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>GroupsModeration Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the GroupsModeration framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>GroupsModeration Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/index.html
+++ b/index.html
@@ -1,55 +1,81 @@
 <!DOCTYPE html>
-<html>
-
-<body>
-<a href="https://githubpagesstuff.github.io/Documentation/abtesting/docs.html">abtesting</a>
-<a href="https://githubpagesstuff.github.io/Documentation/accountinformation/docs.html">accountinformation</a>
-<a href="https://githubpagesstuff.github.io/Documentation/accountsettings/docs.html">accountsettings</a>
-<a href="https://githubpagesstuff.github.io/Documentation/adconfiguration/docs.html">adconfiguration</a>
-<a href="https://githubpagesstuff.github.io/Documentation/ads/docs.html">ads</a>
-<a href="https://githubpagesstuff.github.io/Documentation/api/docs.html">api</a>
-<a href="https://githubpagesstuff.github.io/Documentation/assetdelivery/docs.html">assetdelivery</a>
-<a href="https://githubpagesstuff.github.io/Documentation/auth/docs.html">auth</a>
-<a href="https://githubpagesstuff.github.io/Documentation/avatar/docs.html">avatar</a>
-<a href="https://githubpagesstuff.github.io/Documentation/badges/docs.html">badges</a>
-<a href="https://githubpagesstuff.github.io/Documentation/billing/docs.html">billing</a>
-<a href="https://githubpagesstuff.github.io/Documentation/catalog/docs.html">catalog</a>
-<a href="https://githubpagesstuff.github.io/Documentation/cdnproviders/docs.html">cdnproviders</a>
-<a href="https://githubpagesstuff.github.io/Documentation/chat/docs.html">chat</a>
-<a href="https://githubpagesstuff.github.io/Documentation/clientsettings/docs.html">clientsettings</a>
-<a href="https://githubpagesstuff.github.io/Documentation/contacts/docs.html">contacts</a>
-<a href="https://githubpagesstuff.github.io/Documentation/contentstore/docs.html">contentstore</a>
-<a href="https://githubpagesstuff.github.io/Documentation/develop/docs.html">develop</a>
-<a href="https://githubpagesstuff.github.io/Documentation/economy/docs.html">economy</a>
-<a href="https://githubpagesstuff.github.io/Documentation/engagementpayouts/docs.html">engagementpayouts</a>
-<a href="https://githubpagesstuff.github.io/Documentation/files_api/docs.html">files_api</a>
-<a href="https://githubpagesstuff.github.io/Documentation/followings/docs.html">followings</a>
-<a href="https://githubpagesstuff.github.io/Documentation/friends/docs.html">friends</a>
-<a href="https://githubpagesstuff.github.io/Documentation/gameinternationalization/docs.html">gameinternationalization</a>
-<a href="https://githubpagesstuff.github.io/Documentation/games/docs.html">games</a>
-<a href="https://githubpagesstuff.github.io/Documentation/groups/docs.html">groups</a>
-<a href="https://githubpagesstuff.github.io/Documentation/groupsmoderation/docs.html">groupsmoderation</a>
-<a href="https://githubpagesstuff.github.io/Documentation/inventory/docs.html">inventory</a>
-<a href="https://githubpagesstuff.github.io/Documentation/itemconfiguration/docs.html">itemconfiguration</a>
-<a href="https://githubpagesstuff.github.io/Documentation/locale/docs.html">locale</a>
-<a href="https://githubpagesstuff.github.io/Documentation/localizationtables/docs.html">localizationtables</a>
-<a href="https://githubpagesstuff.github.io/Documentation/metrics/docs.html">metrics</a>
-<a href="https://githubpagesstuff.github.io/Documentation/notifications/docs.html">notifications</a>
-<a href="https://githubpagesstuff.github.io/Documentation/premiumfeatures/docs.html">premiumfeatures</a>
-<a href="https://githubpagesstuff.github.io/Documentation/presence/docs.html">presence</a>
-<a href="https://githubpagesstuff.github.io/Documentation/privatemessages/docs.html">privatemessages</a>
-<a href="https://githubpagesstuff.github.io/Documentation/publish/docs.html">publish</a>
-<a href="https://githubpagesstuff.github.io/Documentation/README.md/docs.html">README.md</a>
-<a href="https://githubpagesstuff.github.io/Documentation/share/docs.html">share</a>
-<a href="https://githubpagesstuff.github.io/Documentation/textfilter/docs.html">textfilter</a>
-<a href="https://githubpagesstuff.github.io/Documentation/thumbnails/docs.html">thumbnails</a>
-<a href="https://githubpagesstuff.github.io/Documentation/thumbnailsresizer/docs.html">thumbnailsresizer</a>
-<a href="https://githubpagesstuff.github.io/Documentation/trades/docs.html">trades</a>
-<a href="https://githubpagesstuff.github.io/Documentation/translationroles/docs.html">translationroles</a>
-<a href="https://githubpagesstuff.github.io/Documentation/twostepverification/docs.html">twostepverification</a>
-<a href="https://githubpagesstuff.github.io/Documentation/usermoderation/docs.html">usermoderation</a>
-<a href="https://githubpagesstuff.github.io/Documentation/users/docs.html">users</a>
-<a href="https://githubpagesstuff.github.io/Documentation/voice/docs.html">voice</a>
-</body>
-
+<html lang="en">
+  <head>
+    <title>Unofficial Roblox Web API Documentation</title>
+    <meta name="description" content="Access to previously documented public endpoints, and undocumented internal endpoints, and backend endpoints of the Roblox Web API.">
+    <meta name="theme-color" content="#7289DA">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <style>
+    ul { list-style-type: none; }
+  </style>
+  <body>
+    <h1>Unofficial ROBLOX Web API Documentation</h1>
+    <h2>What's Different?</h2>
+    <p>Internal APIs (previously undocumented to the public), Backend APIs (previously completely undocumented, even to ROBLOX employees), and overall worse web design. <i>Sorry.</i></p>
+    <h2>How to Use?</h2>
+    <ol>
+      <li>Get the browser extension 'CORS Unblock' (you won't have to do this for long)</li>
+      <li>Press the button for the extension to use APIs here.</li>
+      <li>Turn it off to go on normal ROBLOX.</li>
+    </ol>
+    <h2>Documentation Pages</h2>
+    <ul>
+      <li><a href="Documentation/abtesting/docs.html">A/B Testing</a></li>
+      <li><a href="Documentation/accountinformation/docs.html">AccountInformation</a></li>
+      <li><a href="Documentation/accountsettings/docs.html">AccountSettings</a></li>
+      <li><a href="Documentation/adconfiguration/docs.html">AdConfiguration</a></li>
+      <li><a href="Documentation/ads/docs.html">Ads</a></li>
+      <li><a href="Documentation/api/docs.html">API (api.roblox.com)</a></li>
+      <li><a href="Documentation/assetdelivery/docs.html">AssetDelivery</a></li>
+      <li><a href="Documentation/auth/docs.html">Authentication</a></li>
+      <li><a href="Documentation/avatar/docs.html">Avatar</a></li>
+      <li><a href="Documentation/badges/docs.html">Badges</a></li>
+      <li><a href="Documentation/billing/docs.html">Billing</a></li>
+      <li><a href="Documentation/catalog/docs.html">Catalog</a></li>
+      <li><a href="Documentation/cdnproviders/docs.html">CDNProviders</a></li>
+      <li><a href="Documentation/chat/docs.html">Chat</a></li>
+      <li><a href="Documentation/clientsettings/docs.html">ClientSettings</a></li>
+      <li><a href="Documentation/contacts/docs.html">Contacts</a></li>
+      <li><a href="Documentation/contentstore/docs.html">ContentStore</a></li>
+      <li><a href="Documentation/develop/docs.html">Develop</a></li>
+      <li><a href="Documentation/economy/docs.html">Economy</a></li>
+      <li><a href="Documentation/engagementpayouts/docs.html">EngagementPayouts</a></li>
+      <li><a href="Documentation/files_api/docs.html">Files_API</a></li>
+      <li><a href="Documentation/followings/docs.html">Followings</a></li>
+      <li><a href="Documentation/friends/docs.html">Friends</a></li>
+      <li><a href="Documentation/gameinternationalization/docs.html">GameInternationalization</a></li>
+      <li><a href="Documentation/games/docs.html">Games</a></li>
+      <li><a href="Documentation/groups/docs.html">Groups</a></li>
+      <li><a href="Documentation/groupsmoderation/docs.html">GroupsModeration</a></li>
+      <li><a href="Documentation/inventory/docs.html">Inventory</a></li>
+      <li><a href="Documentation/itemconfiguration/docs.html">ItemConfiguration</a></li>
+      <li><a href="Documentation/locale/docs.html">Locale</a></li>
+      <li><a href="Documentation/localizationtables/docs.html">LocalizationTables</a></li>
+      <li><a href="Documentation/metrics/docs.html">Metrics</a></li>
+      <li><a href="Documentation/notifications/docs.html">Notifications</a></li>
+      <li><a href="Documentation/premiumfeatures/docs.html">PremiumFeatures</a></li>
+      <li><a href="Documentation/presence/docs.html">Presence</a></li>
+      <li><a href="Documentation/privatemessages/docs.html">PrivateMessages</a></li>
+      <li><a href="Documentation/publish/docs.html">Publish</a></li>
+      <li><a href="Documentation/share/docs.html">Share</a></li>
+      <li><a href="Documentation/textfilter/docs.html">Textfilter</a></li>
+      <li><a href="Documentation/thumbnails/docs.html">Thumbnails</a></li>
+      <li><a href="Documentation/thumbnailsresizer/docs.html">ThumbnailsResizer</a></li>
+      <li><a href="Documentation/trades/docs.html">Trades</a></li>
+      <li><a href="Documentation/translationroles/docs.html">TranslationRoles</a></li>
+      <li><a href="Documentation/twostepverification/docs.html">TwoStepVerification</a></li>
+      <li><a href="Documentation/usermoderation/docs.html">UserModeration</a></li>
+      <li><a href="Documentation/users/docs.html">Users</a></li>
+      <li><a href="Documentation/voice/docs.html">Voice</a></li>
+    </ul>
+    <h2>Github Repository</h2>
+    <p>
+      This website is open-source and can be found <a href="https://github.com/GithubPagesStuff/Documentation">here</a>.<br>
+      Feel free to make contributions to add documentation or improve the web design.
+    </p>
+    <h3>Credits</h3>
+    <p>h0nda - for saving JSON files, thanks</p>
+  </body>
 </html>

--- a/inventory/docs.html
+++ b/inventory/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Inventory Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Inventory framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Inventory Api v1</option>
 					<option value="v2" selected>Inventory Api v2</option>

--- a/itemconfiguration/docs.html
+++ b/itemconfiguration/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>ItemConfiguration Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the ItemConfiguration framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>ItemConfiguration Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/locale/docs.html
+++ b/locale/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Locale Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Locale framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Locale Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/localizationtables/docs.html
+++ b/localizationtables/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>LocalizationTables Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the LocalizationTables framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>LocalizationTables Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/metrics/docs.html
+++ b/metrics/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Metrics Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Metrics framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Metrics Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/notifications/docs.html
+++ b/notifications/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Notifications Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Notifications framework</div>
 			<select id="version-selector" class="">
-					<option value="v2" selected>AbTesting Api v1</option>
+					<option value="v2" selected>Notifications Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/premiumfeatures/docs.html
+++ b/premiumfeatures/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>PremiumFeatures Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the PremiumFeatures framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>PremiumFeatures Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/presence/docs.html
+++ b/presence/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Presence Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Presence framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Presence Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/privatemessages/docs.html
+++ b/privatemessages/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>PrivateMessages Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the PrivateMessages framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>PrivateMessages Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/publish/docs.html
+++ b/publish/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Publish Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Publish framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Publish Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/share/docs.html
+++ b/share/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Share Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Share framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Share Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/textfilter/docs.html
+++ b/textfilter/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>TextFilter Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the TextFilter framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>TextFilter Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/thumbnails/docs.html
+++ b/thumbnails/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Thumbnails Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Thumbnails framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Thumbnails Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/thumbnailsresizer/docs.html
+++ b/thumbnailsresizer/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>ThumbnailsResizer Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the ThumbnailsResizer framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>ThumbnailsResizer Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/trades/docs.html
+++ b/trades/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Trades Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Trades framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Trades Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/translationroles/docs.html
+++ b/translationroles/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>TranslationRoles Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the TranslationRoles framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>TranslationRoles Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/twostepverification/docs.html
+++ b/twostepverification/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>TwoStepVerification Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the TwoStepVerification framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>TwoStepVerification Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/usermoderation/docs.html
+++ b/usermoderation/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>UserModeration Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the UserModeration framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>UserModeration Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/users/docs.html
+++ b/users/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Users Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,9 +45,9 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Users framework</div>
 			<select id="version-selector" class="hidden">
-					<option value="v1" selected>AbTesting Api v1</option>
+					<option value="v1" selected>Users Api v1</option>
 			</select>
 		</div>
 		<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>

--- a/voice/docs.html
+++ b/voice/docs.html
@@ -5,7 +5,7 @@
 <!-- Mirrored from abtesting.roblox.com/docs by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 09 Mar 2021 23:55:33 GMT -->
 <head>
 		<meta charset="UTF-8">
-		<title>AbTesting Api</title>
+		<title>Voice Api</title>
 		<link rel="icon" type="image/x-ico" href="favicon.ico" />
 
 		<link href="docs/css/typography-css.css" media="screen" rel="stylesheet" type="text/css" />
@@ -45,7 +45,7 @@
         </div>
         <div class="info" id="doc_info">
 			<div class="info_title" id="Title">Loading documentation...</div>
-			<div class="info_description" id="Description">Endpoints for the A/B Testing framework</div>
+			<div class="info_description" id="Description">Endpoints for the Voice framework</div>
 			<select id="version-selector" class="">
 					<option value="v1" selected>Voice Api v1</option>
 					<option value="v2" selected>Voice Api v2</option>


### PR DESCRIPTION
Fixed the title and headers, so they say their corresponding category: 
![image](https://user-images.githubusercontent.com/34300238/134814270-58dc5557-3f19-4aed-8ee8-5e3a48ee4a61.png)

and cleaned up the index.html so its easier to read; I may come back later with a subsequent PR to add CSS + search and home buttons for the doc pages

![image](https://user-images.githubusercontent.com/34300238/134814336-af047570-8476-464d-aeb8-31cedca71817.png)
